### PR TITLE
Updated to be better when you do the start up command

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const app = express();
 const dir = path.join(__dirname, "/files");
 let dirContents = fs.readdirSync(dir);
 const htmlFile = fs.readFileSync(path.join(__dirname, "/index.html"), "utf8");
-const port = process.argv[2];
+const port = process.argv[2] || 3000;
 const password = "password";
 
 app.use(async (req, res, next) => {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const app = express();
 const dir = path.join(__dirname, "/files");
 let dirContents = fs.readdirSync(dir);
 const htmlFile = fs.readFileSync(path.join(__dirname, "/index.html"), "utf8");
-const port = 3000;
+const port = process.argv[2];
 const password = "password";
 
 app.use(async (req, res, next) => {


### PR DESCRIPTION
This change lets you specify the port when starting up the CDN. for example if you want to start up with port 69420 you can do the start-up command as `node index.js 69420`. this can work with all ports. 

perfect when hosting with pterodactyl panel